### PR TITLE
Possible fix for array of network types issue

### DIFF
--- a/lib/ecto_network/cidr.ex
+++ b/lib/ecto_network/cidr.ex
@@ -3,12 +3,14 @@ defmodule EctoNetwork.CIDR do
 
   def type, do: :cidr
 
+  def cast(%Postgrex.CIDR{}=address), do: {:ok, decode(address)}
   def cast(address) when is_binary(address), do: {:ok, address}
   def cast(_), do: :error
 
   def load(%Postgrex.CIDR{}=address), do: {:ok, address}
   def load(_), do: :error
 
+  def dump(%Postgrex.CIDR{}=address), do: {:ok, address}
   def dump(address) when is_binary(address) do
     [address, netmask] = address |> String.split("/")
 

--- a/test/ecto_network_test.exs
+++ b/test/ecto_network_test.exs
@@ -57,4 +57,18 @@ defmodule EctoNetworkTest do
     assert "#{Enum.at(device.networks, 0)}" == "127.0.0.0/24"
     assert "#{Enum.at(device.networks, 1)}" == "127.0.1.0/24"
   end
+
+  test "allows updates to an array of cidr addresses as binary" do
+    device = TestRepo.insert!(%Device{networks: ["127.0.0.0/24"]})
+
+    # Reload the Device from the Repo, add another IP address, and update
+    device = TestRepo.get(Device, device.id)
+    networks = device.networks ++ ["192.168.0.1/32"]
+    Ecto.Changeset.change(device, networks: networks) |> TestRepo.update!
+
+
+    device = TestRepo.get(Device, device.id)
+    assert "#{Enum.at(device.networks, 0)}" == "127.0.0.0/24"
+    assert "#{Enum.at(device.networks, 1)}" == "192.168.0.1/32"
+  end
 end


### PR DESCRIPTION
There are 2 commits here: The first has a failing test showing what's happening. The second fixes it...or at least the tests pass.

I'll admit: I'm still pretty foggy on how cast/load/dump/etc are supposed to work in Ecto, and the situation gets even foggier when you add arrays into the mix. However, it seems like the casting/loading could use a "null" case where you cast type X to itself, instead of always assuming it will be (or become) a string. Right?

Let me know if this makes sense.
