### PR TITLE
Handle error tuple from :inet.parse_address

### DIFF
--- a/lib/ecto_network/inet.ex
+++ b/lib/ecto_network/inet.ex
@@ -40,7 +40,7 @@ defmodule EctoNetwork.INET do
     |> :inet.parse_address()
     |> case do
       {:ok, address} -> address
-      error -> error
+      {:error, error} -> error
     end
   end
 end

--- a/test/ecto_network_test.exs
+++ b/test/ecto_network_test.exs
@@ -44,6 +44,17 @@ defmodule EctoNetworkTest do
     assert "#{device.ip_address}" == "127.0.0.1"
   end
 
+  test "returns :error when ipv4 is invalid" do
+    result = EctoNetwork.INET.cast("abcd")
+    assert result == :error
+  end
+
+  test "converts ipv4 error into changeset error" do
+    changeset = Device.changeset(%Device{}, %{ip_address: "abcd"})
+    {:error, changeset} = TestRepo.insert(changeset)
+    assert changeset.errors[:ip_address] == {"is invalid", [type: EctoNetwork.INET, validation: :cast]}
+  end
+
   test "accepts ipv6 address as binary and saves" do
     ip_address = "2001:0db8:0000:0000:0000:ff00:0042:8329"
     short_ip_address = "2001:db8::ff00:42:8329"


### PR DESCRIPTION
When parsing of an ip address failed the erlang function `:inet.parse_address()` would return a touple `{:error, :einval}` which was then matched in the `cast()` function as a correct value, because it is a tuple:
```elixir
address when is_tuple(address) -> cast(%Postgrex.INET{address: address})
```
So instead of returning `:error` the cast function would return `%Postgrex.INET{address: {:error, :einval}}` which caused a changeset to not mark the field as invalid.
This PR catches errors from `:inet.parse_address()` and passes the error atom to `cast()` which is then handled by `_ -> :error`.
This will now return a changeset which marks the field as an error and can also be used in phoenix forms with correct error messages:
```eex
<div class="form-group">
    <%= label f, :ip, class: "control-label" %>
    <%= text_input f, :ip, class: "form-control" %>
    <%= error_tag f, :ip %>
</div>
```