### PR TITLE
Support for Postgrex.CIDR/INET unification

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,8 @@
+[
+  inputs: [
+    "mix.exs",
+    "{lib,test}/**/*.{ex,exs}"
+  ],
+  import_deps: [:ecto],
+  locals_without_parens: []
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Update to work with Ecto 3.0 (master) and Postgrex 0.14 (master).
 
 ## [v0.7.0] - 2017-11-16
 - Update mix dependencies

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Adam Daniels
+Copyright (c) 2016-2018 Adam Daniels and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ due to the types it is providing.
 
     ```elixir
     def deps do
-      [{:ecto_network, "~> 0.6.0"}]
+      [{:ecto_network, "~> 0.7.0"}]
     end
     ```
 

--- a/lib/ecto_network/cidr.ex
+++ b/lib/ecto_network/cidr.ex
@@ -7,45 +7,15 @@ defmodule EctoNetwork.CIDR do
 
   def type, do: :cidr
 
-  @doc "Handle casting to Postgrex.CIDR"
-  def cast(%Postgrex.CIDR{}=address), do: {:ok, address}
-  def cast(address) when is_binary(address) do
-    [address, netmask] = address |> String.split("/")
-
-    {:ok, parsed_address} =
-      address
-      |> String.to_charlist()
-      |> :inet.parse_address
-
-    netmask = netmask |> String.to_integer()
-
-    {:ok, %Postgrex.CIDR{address: parsed_address, netmask: netmask}}
-  end
-  def cast(_), do: :error
+  @doc "Handle casting to Postgrex.INET"
+  defdelegate cast(address), to: EctoNetwork.INET
 
   @doc "Load from the native Ecto representation"
-  def load(%Postgrex.CIDR{}=address), do: {:ok, address}
-  def load(_), do: :error
+  defdelegate load(address), to: EctoNetwork.INET
 
   @doc "Convert to the native Ecto representation"
-  def dump(%Postgrex.CIDR{}=address), do: {:ok, address}
-  def dump(_), do: :error
+  defdelegate dump(address), to: EctoNetwork.INET
 
   @doc "Convert from native Ecto representation to a binary"
-  def decode(%Postgrex.CIDR{address: address, netmask: netmask}) do
-    case :inet.ntoa(address) do
-      {:error, _einval} -> :error
-      formatted_address -> List.to_string(formatted_address) <> "/#{netmask}"
-    end
-  end
-end
-
-defimpl String.Chars, for: Postgrex.CIDR do
-  def to_string(%Postgrex.CIDR{}=address), do: EctoNetwork.CIDR.decode(address)
-end
-
-if Code.ensure_loaded?(Phoenix.HTML) do
-  defimpl Phoenix.HTML.Safe, for: Postgrex.CIDR do
-    def to_iodata(%Postgrex.CIDR{}=address), do: EctoNetwork.CIDR.decode(address)
-  end
+  defdelegate decode(address), to: EctoNetwork.INET
 end

--- a/lib/ecto_network/inet.ex
+++ b/lib/ecto_network/inet.ex
@@ -8,49 +8,80 @@ defmodule EctoNetwork.INET do
   def type, do: :inet
 
   @doc "Handle casting to Postgrex.INET"
-  def cast(address) do
-    address
-    |> case do
-      %Postgrex.INET{}=address -> {:ok, address}
-      address when is_tuple(address) -> cast(%Postgrex.INET{address: address})
-      address when is_binary(address) -> parse_address(address) |> cast()
-      _ -> :error
-    end
-  end
+  def cast(%Postgrex.INET{} = address), do: {:ok, address}
 
-  @doc "Load from the native Ecto representation"
-  def load(%Postgrex.INET{}=address), do: {:ok, address}
-  def load(_), do: :error
+  def cast(address) when is_tuple(address),
+    do: cast(%Postgrex.INET{address: address, netmask: address_netmask(address)})
 
-  @doc "Convert to the native Ecto representation"
-  def dump(%Postgrex.INET{}=address), do: {:ok, address}
-  def dump(_), do: :error
+  def cast(address) when is_binary(address) do
+    {address, netmask} =
+      case String.split(address, "/") do
+        [address] -> {address, nil}
+        [address, netmask] -> {address, netmask}
+        [address, netmask | _] -> {address, netmask}
+      end
 
-  @doc "Convert from native Ecto representation to a binary"
-  def decode(%Postgrex.INET{address: address}) do
-    case :inet.ntoa(address) do
-      {:error, _einval} -> :error
-      formated_address  -> List.to_string(formated_address)
-    end
-  end
-
-  defp parse_address(address) do
     address
     |> String.to_charlist()
     |> :inet.parse_address()
     |> case do
-      {:ok, address} -> address
-      {:error, error} -> error
+      {:ok, address} ->
+        netmask =
+          if netmask do
+            String.to_integer(netmask)
+          else
+            address_netmask(address)
+          end
+
+        {:ok, %Postgrex.INET{address: address, netmask: netmask}}
+
+      {:error, _} ->
+        :error
     end
+  end
+
+  def cast(_), do: :error
+
+  @doc "Load from the native Ecto representation"
+  def load(%Postgrex.INET{} = address), do: {:ok, address}
+  def load(_), do: :error
+
+  @doc "Convert to the native Ecto representation"
+  def dump(%Postgrex.INET{} = address), do: {:ok, address}
+  def dump(_), do: :error
+
+  @doc "Convert from native Ecto representation to a binary"
+  def decode(%Postgrex.INET{address: address, netmask: netmask}) do
+    netmask =
+      cond do
+        tuple_size(address) == 4 && netmask == 32 -> nil
+        tuple_size(address) == 8 && netmask == 128 -> nil
+        true -> netmask
+      end
+
+    address
+    |> :inet.ntoa()
+    |> case do
+      {:error, _} ->
+        :error
+
+      address ->
+        address = List.to_string(address)
+        if netmask, do: "#{address}/#{netmask}", else: address
+    end
+  end
+
+  defp address_netmask(address) do
+    if(tuple_size(address) == 4, do: 32, else: 128)
   end
 end
 
 defimpl String.Chars, for: Postgrex.INET do
-  def to_string(%Postgrex.INET{}=address), do: EctoNetwork.INET.decode(address)
+  def to_string(%Postgrex.INET{} = address), do: EctoNetwork.INET.decode(address)
 end
 
 if Code.ensure_loaded?(Phoenix.HTML) do
   defimpl Phoenix.HTML.Safe, for: Postgrex.INET do
-    def to_iodata(%Postgrex.INET{}=address), do: EctoNetwork.INET.decode(address)
+    def to_iodata(%Postgrex.INET{} = address), do: EctoNetwork.INET.decode(address)
   end
 end

--- a/lib/ecto_network/macaddr.ex
+++ b/lib/ecto_network/macaddr.ex
@@ -8,7 +8,8 @@ defmodule EctoNetwork.MACADDR do
   def type, do: :macaddr
 
   @doc "Handle casting to Postgrex.MACADDR"
-  def cast(%Postgrex.MACADDR{}=address), do: {:ok, address}
+  def cast(%Postgrex.MACADDR{} = address), do: {:ok, address}
+
   def cast(address) when is_binary(address) do
     [a, b, c, d, e, f] =
       address
@@ -19,11 +20,11 @@ defmodule EctoNetwork.MACADDR do
   end
 
   @doc "Load from the native Ecto representation"
-  def load(%Postgrex.MACADDR{}=address), do: {:ok, address}
+  def load(%Postgrex.MACADDR{} = address), do: {:ok, address}
   def load(_), do: :error
 
   @doc "Convert to the native Ecto representation"
-  def dump(%Postgrex.MACADDR{}=address), do: {:ok, address}
+  def dump(%Postgrex.MACADDR{} = address), do: {:ok, address}
   def dump(_), do: :error
 
   @doc "Convert from native Ecto representation to a binary"
@@ -36,11 +37,11 @@ defmodule EctoNetwork.MACADDR do
 end
 
 defimpl String.Chars, for: Postgrex.MACADDR do
-  def to_string(%Postgrex.MACADDR{}=address), do: EctoNetwork.MACADDR.decode(address)
+  def to_string(%Postgrex.MACADDR{} = address), do: EctoNetwork.MACADDR.decode(address)
 end
 
 if Code.ensure_loaded?(Phoenix.HTML) do
   defimpl Phoenix.HTML.Safe, for: Postgrex.MACADDR do
-    def to_iodata(%Postgrex.MACADDR{}=address), do: EctoNetwork.MACADDR.decode(address)
+    def to_iodata(%Postgrex.MACADDR{} = address), do: EctoNetwork.MACADDR.decode(address)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,19 +4,23 @@ defmodule EctoNetwork.Mixfile do
   @version "0.7.0"
 
   def project do
-    [app: :ecto_network,
-     version: @version,
-     elixir: "~> 1.3",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps(),
-     description: description(),
-     package: package(),
-     name: "EctoNetwork",
-     docs: [extras: ["README.md", "CHANGELOG.md"], main: "readme",
-            source_ref: "v#{@version}",
-            source_url: "https://github.com/adam12/ecto_network",
-           ]]
+    [
+      app: :ecto_network,
+      version: @version,
+      elixir: "~> 1.3",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      description: description(),
+      package: package(),
+      name: "EctoNetwork",
+      docs: [
+        extras: ["README.md", "CHANGELOG.md"],
+        main: "readme",
+        source_ref: "v#{@version}",
+        source_url: "https://github.com/adam12/ecto_network"
+      ]
+    ]
   end
 
   def application do
@@ -24,10 +28,15 @@ defmodule EctoNetwork.Mixfile do
   end
 
   defp deps do
-    [{:ecto, ">= 0.0.0"},
-     {:postgrex, ">= 0.0.0"},
-     {:phoenix_html, ">= 0.0.0", [optional: true]},
-     {:ex_doc, ">= 0.0.0", only: :dev}]
+    # On release, this will need to be set to
+    # {:postgrex, ">= 0.14.0"}
+    [
+      {:db_connection, github: "elixir-ecto/db_connection", override: true},
+      {:ecto, github: "elixir-ecto/ecto"},
+      {:postgrex, github: "elixir-ecto/postgrex"},
+      {:phoenix_html, ">= 0.0.0", [optional: true]},
+      {:ex_doc, ">= 0.0.0", only: :dev}
+    ]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,11 +1,13 @@
-%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
-  "db_connection": {:hex, :db_connection, "1.1.2", "2865c2a4bae0714e2213a0ce60a1b12d76a6efba0c51fbda59c9ab8d1accc7a8", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
-  "decimal": {:hex, :decimal, "1.4.1", "ad9e501edf7322f122f7fc151cce7c2a0c9ada96f2b0155b8a09a795c2029770", [:mix], [], "hexpm"},
+%{
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
+  "db_connection": {:git, "https://github.com/elixir-ecto/db_connection.git", "3b34256817f19430e0f1e654097d127c75ea73d7", []},
+  "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
-  "ecto": {:hex, :ecto, "2.2.6", "3fd1067661d6d64851a0d4db9acd9e884c00d2d1aa41cc09da687226cf894661", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "ecto": {:git, "https://github.com/elixir-ecto/ecto.git", "ce362f8f54f77c67d591d15417943e163256ae1f", []},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [], [], "hexpm"},
+  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], [], "hexpm"},
   "phoenix_html": {:hex, :phoenix_html, "2.10.5", "4f9df6b0fb7422a9440a73182a566cb9cbe0e3ffe8884ef9337ccf284fc1ef0a", [:mix], [{:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "plug": {:hex, :plug, "1.4.3", "236d77ce7bf3e3a2668dc0d32a9b6f1f9b1f05361019946aae49874904be4aed", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
-  "postgrex": {:hex, :postgrex, "0.13.3", "c277cfb2a9c5034d445a722494c13359e361d344ef6f25d604c2353185682bfc", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"}}
+  "postgrex": {:git, "https://github.com/elixir-ecto/postgrex.git", "43aa6b964043dd8726dba363245aebd3734bde47", []},
+}

--- a/test/ecto_migration.exs
+++ b/test/ecto_migration.exs
@@ -3,10 +3,10 @@ defmodule Ecto.Integration.Migration do
 
   def change do
     create table(:devices) do
-      add :macaddr, :macaddr
-      add :ip_address, :inet
-      add :network, :cidr
-      add :networks, {:array, :cidr}
+      add(:macaddr, :macaddr)
+      add(:ip_address, :inet)
+      add(:network, :cidr)
+      add(:networks, {:array, :cidr})
     end
   end
 end

--- a/test/ecto_network_test.exs
+++ b/test/ecto_network_test.exs
@@ -7,13 +7,13 @@ defmodule EctoNetworkTest do
     import Ecto.Changeset
 
     schema "devices" do
-      field :macaddr, EctoNetwork.MACADDR
-      field :ip_address, EctoNetwork.INET
-      field :network, EctoNetwork.CIDR
-      field :networks, {:array, EctoNetwork.CIDR}
+      field(:macaddr, EctoNetwork.MACADDR)
+      field(:ip_address, EctoNetwork.INET)
+      field(:network, EctoNetwork.CIDR)
+      field(:networks, {:array, EctoNetwork.CIDR})
     end
 
-    @required ~w(macaddr ip_address network networks)
+    @required ~w(macaddr ip_address network networks)a
 
     def changeset(struct, params \\ %{}) do
       struct
@@ -52,7 +52,9 @@ defmodule EctoNetworkTest do
   test "converts ipv4 error into changeset error" do
     changeset = Device.changeset(%Device{}, %{ip_address: "abcd"})
     {:error, changeset} = TestRepo.insert(changeset)
-    assert changeset.errors[:ip_address] == {"is invalid", [type: EctoNetwork.INET, validation: :cast]}
+
+    assert changeset.errors[:ip_address] ==
+             {"is invalid", [type: EctoNetwork.INET, validation: :cast]}
   end
 
   test "accepts ipv6 address as binary and saves" do
@@ -66,7 +68,7 @@ defmodule EctoNetworkTest do
   end
 
   test "accepts ipv4 address as tuple and saves" do
-    changeset = Device.changeset(%Device{}, %{ip_address: {127,0,0,1}})
+    changeset = Device.changeset(%Device{}, %{ip_address: {127, 0, 0, 1}})
     device = TestRepo.insert!(changeset)
     device = TestRepo.get(Device, device.id)
 
@@ -109,10 +111,13 @@ defmodule EctoNetworkTest do
   end
 
   test "accepts array of cidr addresses as mixed types and saves" do
-    changeset = Device.changeset(%Device{}, %{networks: [
-         %Postgrex.CIDR{address: {127, 0, 0, 0}, netmask: 24},
-         "127.0.1.0/24"
-    ]})
+    changeset =
+      Device.changeset(%Device{}, %{
+        networks: [
+          %Postgrex.INET{address: {127, 0, 0, 0}, netmask: 24},
+          "127.0.1.0/24"
+        ]
+      })
 
     device = TestRepo.insert!(changeset)
     device = TestRepo.get(Device, device.id)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,10 +2,13 @@ ExUnit.start()
 
 alias Ecto.Integration.TestRepo
 
-Application.put_env(:ecto, TestRepo,
+Application.put_env(
+  :ecto,
+  TestRepo,
   adapter: Ecto.Adapters.Postgres,
   url: "ecto://localhost/ecto_network_test",
-  pool: Ecto.Adapters.SQL.Sandbox)
+  pool: Ecto.Adapters.SQL.Sandbox
+)
 
 defmodule Ecto.Integration.TestRepo do
   use Ecto.Repo, otp_app: :ecto
@@ -13,12 +16,12 @@ end
 
 {:ok, _} = Ecto.Adapters.Postgres.ensure_all_started(TestRepo, :temporary)
 
-_ = Ecto.Adapters.Postgres.storage_down(TestRepo.config)
-:ok = Ecto.Adapters.Postgres.storage_up(TestRepo.config)
+_ = Ecto.Adapters.Postgres.storage_down(TestRepo.config())
+:ok = Ecto.Adapters.Postgres.storage_up(TestRepo.config())
 
-{:ok, _pid} = TestRepo.start_link
+{:ok, _pid} = TestRepo.start_link()
 
-Code.require_file "ecto_migration.exs", __DIR__
+Code.require_file("ecto_migration.exs", __DIR__)
 
 :ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration, log: false)
 Ecto.Adapters.SQL.Sandbox.mode(TestRepo, :manual)


### PR DESCRIPTION
- This is part of the forthcoming Postgrex 0.14. As this is a breaking change, I will be filing a bug with Postgrex on this issue (elixir-ecto/postgrex#383). However, it is a good change that I will be recommending they implement Postgrex.CIDR as a transparent layer over Postgrex.INET.

- I am implementing this as a transparent implementation so that existing users are not required to change code that may be using EctoNetwork.CIDR.

- I recommend that instead of 0.7.0 being the release version, this bump EctoNetwork to v1.0 because of the changed dependency in Postgrex.

- I have applied mix format and provided a default .formatter.exs.