### PR TITLE
Ecto 3.2 Support - Add new Ecto.Type callbacks

### DIFF
--- a/lib/ecto_network/cidr.ex
+++ b/lib/ecto_network/cidr.ex
@@ -7,6 +7,12 @@ defmodule EctoNetwork.CIDR do
 
   def type, do: :cidr
 
+  @doc "Handle embedding format for CIDR records."
+  defdelegate embed_as(format), to: EctoNetwork.INET
+
+  @doc "Handle equality testing for CIDR records."
+  defdelegate equal?(left, right), to: EctoNetwork.INET
+
   @doc "Handle casting to Postgrex.INET"
   defdelegate cast(address), to: EctoNetwork.INET
 

--- a/lib/ecto_network/inet.ex
+++ b/lib/ecto_network/inet.ex
@@ -7,6 +7,12 @@ defmodule EctoNetwork.INET do
 
   def type, do: :inet
 
+  @doc "Handle embedding format for CIDR records."
+  def embed_as(_), do: :self
+
+  @doc "Handle equality testing for CIDR records."
+  def equal?(left, right), do: left == right
+
   @doc "Handle casting to Postgrex.INET"
   def cast(%Postgrex.INET{} = address), do: {:ok, address}
 

--- a/lib/ecto_network/macaddr.ex
+++ b/lib/ecto_network/macaddr.ex
@@ -7,6 +7,12 @@ defmodule EctoNetwork.MACADDR do
 
   def type, do: :macaddr
 
+  @doc "Handle embedding format for CIDR records."
+  def embed_as(_), do: :self
+
+  @doc "Handle equality testing for CIDR records."
+  def equal?(left, right), do: left == right
+
   @doc "Handle casting to Postgrex.MACADDR"
   def cast(%Postgrex.MACADDR{} = address), do: {:ok, address}
 


### PR DESCRIPTION
- Ecto 3.2 adds some new type callbacks. As a convenience, there is now a `use
  Ecto.Type` that provides default implementations, but to keep compatibility
  with Ecto 3.0 and 3.1, I have implemented the defaults by hand.

- The embedding definition for Ecto 3.2 _may_ be too limited as I am not sure
  that the CIDR, INET, and MACADDR representations supported by ECtoNetwork can
  be safely embedded. This will require tests and possible changes to Ecto to
  fix.