### PR TITLE
Safely handle invalid mac addresses

### DIFF
--- a/test/ecto_network_test.exs
+++ b/test/ecto_network_test.exs
@@ -36,6 +36,14 @@ defmodule EctoNetworkTest do
     assert String.downcase("#{device.macaddr}") == String.downcase("02:01:00:0A:00:FF")
   end
 
+  test "returns changeset error when mac address is invalid" do
+    changeset = Device.changeset(%Device{}, %{macaddr: "notamac"})
+    assert {:error, invalid_changeset} = TestRepo.insert(changeset)
+
+    assert changeset.errors[:macaddr] ==
+             {"is invalid", [type: EctoNetwork.MACADDR, validation: :cast]}
+  end
+
   test "accepts ipv4 address as binary and saves" do
     changeset = Device.changeset(%Device{}, %{ip_address: "127.0.0.1"})
     device = TestRepo.insert!(changeset)


### PR DESCRIPTION
Thanks for putting this library together and bringing this great set of types to us in the Ecto world!

When I tried out the lib, I was surprised by the following argument error which is raised when an invalid mac is passed in:
```  
1) test returns changeset error when mac address is invalid (EctoNetworkTest)
     test/ecto_network_test.exs:39
     ** (ArgumentError) argument error
     code: changeset = Device.changeset(%Device{}, %{macaddr: "notamac"})
     stacktrace:
       :erlang.binary_to_integer("notamac", 16)
       (ecto_network) lib/ecto_network/macaddr.ex:23: anonymous fn/1 in EctoNetwork.MACADDR.cast/1
       (elixir) lib/enum.ex:1336: Enum."-map/2-lists^map/1-0-"/2
       (ecto_network) lib/ecto_network/macaddr.ex:23: EctoNetwork.MACADDR.cast/1
       (ecto) lib/ecto/changeset.ex:566: Ecto.Changeset.cast_field/8
       (ecto) lib/ecto/changeset.ex:527: Ecto.Changeset.process_param/7
       (elixir) lib/enum.ex:1948: Enum."-reduce/3-lists^foldl/2-0-"/3
       (ecto) lib/ecto/changeset.ex:504: Ecto.Changeset.cast/6
       test/ecto_network_test.exs:40: (test)
```

I determined the source of this error to be the use of `String.to_integer/2`, so I have updated it to use `Integer.parse/2` which does not raise an argument error when it encounters unexpected input.

Please let me know what you think.