### PR TITLE
Add @type annotations

### DIFF
--- a/lib/ecto_network/cidr.ex
+++ b/lib/ecto_network/cidr.ex
@@ -5,6 +5,8 @@ defmodule EctoNetwork.CIDR do
 
   @behaviour Ecto.Type
 
+  @type t :: EctoNetwork.INET.t()
+
   def type, do: :cidr
 
   @doc "Handle embedding format for CIDR records."

--- a/lib/ecto_network/inet.ex
+++ b/lib/ecto_network/inet.ex
@@ -5,6 +5,8 @@ defmodule EctoNetwork.INET do
 
   @behaviour Ecto.Type
 
+  @type t :: Postgrex.INET.t()
+
   def type, do: :inet
 
   @doc "Handle embedding format for CIDR records."

--- a/lib/ecto_network/macaddr.ex
+++ b/lib/ecto_network/macaddr.ex
@@ -5,6 +5,8 @@ defmodule EctoNetwork.MACADDR do
 
   @behaviour Ecto.Type
 
+  @type t :: Postgrex.MACADDR.t()
+
   def type, do: :macaddr
 
   @doc "Handle embedding format for CIDR records."


### PR DESCRIPTION
Hi there! Thanks for this package—it's simple and effective! ☺️

This PR adds a type definition to the three `Ecto.Type`s provided by the package. This is particularly useful when using [the `TypedEctoSchema` library](https://github.com/bamorim/typed_ecto_schema), where you'd like to be able to write something like:

```elixir
typed_schema "anonymous_commenters" do
  field :ip_address, EctoNetwork.INET
end
```

...and have that automatically produce a nice typespec for your module.