### PR TITLE
Parse addresses in strict mode

### DIFF
--- a/lib/ecto_network/inet.ex
+++ b/lib/ecto_network/inet.ex
@@ -33,7 +33,7 @@ defmodule EctoNetwork.INET do
       address
       |> String.trim()
       |> String.to_charlist()
-      |> :inet.parse_address()
+      |> :inet.parse_strict_address()
 
     parsed_netmask = cast_netmask(netmask, parsed_address)
 

--- a/test/ecto_network_test.exs
+++ b/test/ecto_network_test.exs
@@ -65,6 +65,14 @@ defmodule EctoNetworkTest do
              {"is invalid", [type: EctoNetwork.INET, validation: :cast]}
   end
 
+  test "converts shortened address into changeset error" do
+    changeset = Device.changeset(%Device{}, %{ip_address: "111"})
+    {:error, changeset} = TestRepo.insert(changeset)
+
+    assert changeset.errors[:ip_address] ==
+             {"is invalid", [type: EctoNetwork.INET, validation: :cast]}
+  end
+
   test "converts ipv4 with incomplete CIDR into changeset error" do
     changeset = Device.changeset(%Device{}, %{ip_address: "1.2.3.0/"})
     {:error, changeset} = TestRepo.insert(changeset)


### PR DESCRIPTION
Hey,
This PR makes addresses such as "111" invalid.
I could make this a compile-time generated `inet_strict` type, if the non-strict parser was intentional.
