### PR TITLE
Add Elixir 1.20 to test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        elixir_version: [1.17, 1.16]
+        elixir_version: ["1.20", 1.17, 1.16]
     runs-on: ubuntu-latest
     container:
       image: elixir:${{ matrix.elixir_version }}


### PR DESCRIPTION
Adds Elixir 1.20 to the CI matrix (`major.minor`, consistent with the existing entries). The full suite passes locally on 1.20.1 against PostgreSQL 14.