### PR TITLE
Remove unreachable valid_ip_address?/1 clause

### DIFF
--- a/lib/ecto_network/inet.ex
+++ b/lib/ecto_network/inet.ex
@@ -132,8 +132,6 @@ defmodule EctoNetwork.INET do
       _ -> false
     end
   end
-
-  defp valid_ip_address?(_), do: false
 end
 
 defimpl String.Chars, for: Postgrex.INET do


### PR DESCRIPTION
Elixir 1.20's stricter clause-reachability analysis flags the `valid_ip_address?(_)` fallback at `lib/ecto_network/inet.ex:136` as never used. The sole caller (`cast/1`) is already guarded by `when is_tuple(address)`, so the `is_tuple/1` clause always matches and the fallback is dead code. Removing it silences the warning; all 20 tests still pass on 1.20.1.