### PR TITLE
Remove EOL Elixir versions from test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        elixir_version: [1.17, 1.16, 1.15, 1.14, 1.13]
+        elixir_version: [1.17, 1.16]
     runs-on: ubuntu-latest
     container:
       image: elixir:${{ matrix.elixir_version }}


### PR DESCRIPTION
Drops end-of-life Elixir versions from the CI matrix, leaving `[1.17, 1.16]`.

`ecto` and `ecto_sql` now require Elixir `~> 1.14`, so 1.13 no longer compiles (`Macro.inspect_atom/2 is undefined`) — that's the current CI breakage on `master`. Per Elixir's support policy (only the last 5 minor branches receive security patches), 1.13–1.15 are EOL and are removed here.